### PR TITLE
Only resolve path if tsconfig present

### DIFF
--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -73,8 +73,8 @@ export function resolveConfigPath(
     return absolutePath;
   }
 
-  const configAbsolutePath = path.resolve(walkForTsConfig(cwd));
-  return configAbsolutePath;
+  const configAbsolutePath = walkForTsConfig(cwd);
+  return configAbsolutePath ? path.resolve(configAbsolutePath) : undefined;
 }
 
 export function walkForTsConfig(


### PR DESCRIPTION
Since release `2.7.2` there is an error if no `tsconfig.json` file is present
```
path.js:28
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path', 'string');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string
    at assertPath (path.js:28:11)
    at Object.resolve (path.js:1179:7)
    at resolveConfigPath (/home/nschoenmaker/projects/libs/bla/node_modules/tsconfig-paths/lib/tsconfig-loader.js:41:35)
    at loadSyncDefault (/home/nschoenmaker/projects/libs/bla/node_modules/tsconfig-paths/lib/tsconfig-loader.js:19:22)
    at tsConfigLoader (/home/nschoenmaker/projects/libs/bla/node_modules/tsconfig-paths/lib/tsconfig-loader.js:13:22)
    at Object.configLoader (/home/nschoenmaker/projects/libs/bla/node_modules/tsconfig-paths/lib/config-loader.js:26:22)
    at Object.register (/home/nschoenmaker/projects/libs/bla/node_modules/tsconfig-paths/lib/register.js:9:46)
    at Object.<anonymous> (/home/nschoenmaker/projects/libs/bla/node_modules/tsconfig-paths/register.js:1:77)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
```

Steps to reproduce:
Add a `package.json`
```json
{
  "dependencies": {
    "tsconfig-paths": "^2.7.2"
  }
}
```

And a file called `bug.js`
```js
require('tsconfig-paths/register');
console.log('Hello, world');
```

Then run `node bug.js`

Expected output:
```
Couldn't find tsconfig.json. tsconfig-paths will be skipped
Hello, world
```

Actual output: see above.