### PR TITLE
Fix async recursion

### DIFF
--- a/src/match-path-async.ts
+++ b/src/match-path-async.ts
@@ -131,15 +131,20 @@ function findFirstExistingPath(
             index + 1
           );
         });
+      } else {
+        // This is async code, we need to return in an else-branch otherwise the code still falls through and keeps recursing.
+        // While this might work in general, libraries that use neo-async like Webpack will actually not allow you to call the same callback twice.
+        // An example of where this caused issues: https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/11
+
+        // Continue with the next path
+        return findFirstExistingPath(
+          tryPaths,
+          readJson,
+          fileExists,
+          doneCallback,
+          index + 1
+        );
       }
-      // Continue with the next path
-      return findFirstExistingPath(
-        tryPaths,
-        readJson,
-        fileExists,
-        doneCallback,
-        index + 1
-      );
     });
   } else {
     TryPath.exhaustiveTypeException(tryPath.type);


### PR DESCRIPTION
Right, so this is becoming a longer story then I initially thought :)

I actually found a proper way to reproduce the issue reported in the webpack plugin: https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/11 you can find it in my [own fork](https://github.com/Nayni/tsconfig-paths-webpack-plugin/blob/example-with-node-modules-fallback/example/tsconfig.json). Basically the problem is that if you let the final resolution be a node_module (which was also the case in that issue) the recursion wasn't handled properly.

It took me a while to actually figure out why this was happening but it ended up being an implicit fallthrough that would basically keep the recursion going. I've put a comment in the code to explain it explicitly.

When I fixed this up, the example I made where I experienced the same error as the issue in the webpack plugin also disapeared. 

If you'd like the updated example from my fork for future reference and testing, I'm happy to add it as a PR there.

TL;DR: async code with callbacks is hard :)