### PR TITLE
Fixes #31: Problem when using a custom configFile name

### DIFF
--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -73,6 +73,10 @@ export function resolveConfigPath(
     return absolutePath;
   }
 
+  if (fs.statSync(cwd).isFile()) {
+    return path.resolve(cwd);
+  }
+
   const configAbsolutePath = walkForTsConfig(cwd);
   return configAbsolutePath ? path.resolve(configAbsolutePath) : undefined;
 }

--- a/test/config-loader-tests.ts
+++ b/test/config-loader-tests.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import {
   configLoader,
+  loadConfig,
   ConfigLoaderFailResult,
   ConfigLoaderSuccessResult
 } from "../src/config-loader";
@@ -72,5 +73,18 @@ describe("config-loader", (): void => {
     const failResult = result as ConfigLoaderFailResult;
     assert.equal(failResult.resultType, "failed");
     assert.isTrue(failResult.message.indexOf("baseUrl") > -1);
+  });
+
+  it("should presume cwd to be a tsconfig file when loadConfig is called with absolute path to tsconfig.json", () => {
+    // using tsconfig-named.json to ensure that future changes to fix
+    // https://github.com/dividab/tsconfig-paths/issues/31
+    // do not pass this test case just because of a directory walk looking
+    // for tsconfig.json
+    const configFile = join(__dirname, "tsconfig-named.json");
+    const result = loadConfig(configFile);
+
+    const successResult = result as ConfigLoaderSuccessResult;
+    assert.equal(successResult.resultType, "success");
+    assert.equal(successResult.configFileAbsolutePath, configFile);
   });
 });

--- a/test/tsconfig-named.json
+++ b/test/tsconfig-named.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../base-tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "commonjs",
+    "target": "es6",
+    "sourceMap": true,
+    "outDir": "./js_out"
+  }
+}


### PR DESCRIPTION
This is an opinionated way of solving for #31 by checking deep inside the call stack if we've received the path to tsconfig. Tests are included.

The other way of addressing this issue would require change to the loadConfig() signature, and corresponding changes to tsconfig-paths-webpack-plugin as well. I felt that'd be a larger change.