### PR TITLE
Add support for providing a list of field names to try instead of just using "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,14 @@ export interface MatchPath {
  * @param tsConfigPath The paths where tsconfig.json is located.
  * @param baseUrl The baseUrl specified in tsconfig.
  * @param paths The paths specified in tsconfig.
+ * @param mainFields A list of package.json field names to try when resolving module files.
  */
 export function createMatchPath(
   absoluteBaseUrl: string,
-  paths: { [key: string]: Array<string> }
-): MatchPath
+  paths: { [key: string]: Array<string> },
+  mainFields: string[] = ["main"]
+): MatchPath {
+
 ```
 
 The `createMatchPath` function will create a function that can match paths. It accepts `baseUrl` and `paths` directly as they are specified in tsconfig and will handle resolving paths to absolute form. The created function has the signare specified by the type `MatchPath` above.
@@ -144,6 +147,7 @@ The `createMatchPath` function will create a function that can match paths. It a
  * @param readJson Function that can read json from a path (useful for testing).
  * @param fileExists Function that checks for existance of a file at a path (useful for testing).
  * @param extensions File extensions to probe for (useful for testing).
+ * @param mainFields A list of package.json field names to try when resolving module files.
  * @returns the found path, or undefined if no path was found.
  */
 export function matchFromAbsolutePaths(
@@ -151,8 +155,9 @@ export function matchFromAbsolutePaths(
   requestedModule: string,
   readJson: Filesystem.ReadJsonSync = Filesystem.readJsonFromDiskSync,
   fileExists: Filesystem.FileExistsSync = Filesystem.fileExistsSync,
-  extensions: Array<string> = Object.keys(require.extensions)
-): string | undefined
+  extensions: Array<string> = Object.keys(require.extensions),
+  mainFields: string[] = ["main"]
+): string | undefined {
 ```
 
 This function is lower level and requries that the paths as already been resolved to absolute form and sorted in correct order into an array.

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
  * Typing for the fields of package.json we care about
  */
 export interface PackageJson {
-  readonly main?: string;
+  [key: string]: string;
 }
 
 /**

--- a/src/match-path-async.ts
+++ b/src/match-path-async.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as TryPath from "./try-path";
 import * as MappingEntry from "./mapping-entry";
 import * as Filesystem from "./filesystem";
+import { getPrioritizedMainFieldName } from "./match-path-sync";
 
 /**
  * Function that can match a path async
@@ -81,27 +82,6 @@ export function matchFromAbsolutePathsAsync(
     0,
     mainFields
   );
-}
-
-/**
- * Given a (possibly undefiend) package.json object, return the first
- * defined field name from a prioritized list. Returns undefined if no field name
- * in the list is defined in the object.
- */
-function getPrioritizedMainFieldName(
-  packageJson: { [key: string]: Object } | undefined,
-  mainFields: string[]
-): string | undefined {
-  if (packageJson) {
-    for (let index = 0; index < mainFields.length; index++) {
-      const mainFieldsName = mainFields[index];
-      if (packageJson[mainFieldsName]) {
-        return mainFieldsName;
-      }
-    }
-  }
-
-  return undefined;
 }
 
 // Recursive loop to probe for physical files

--- a/src/match-path-sync.ts
+++ b/src/match-path-sync.ts
@@ -20,6 +20,7 @@ export interface MatchPath {
  * @param tsConfigPath The paths where tsconfig.json is located.
  * @param baseUrl The baseUrl specified in tsconfig.
  * @param paths The paths specified in tsconfig.
+ * @param mainFields A list of package.json field names to try when resolving module files.
  */
 export function createMatchPath(
   absoluteBaseUrl: string,
@@ -54,6 +55,7 @@ export function createMatchPath(
  * @param readJson Function that can read json from a path (useful for testing).
  * @param fileExists Function that checks for existance of a file at a path (useful for testing).
  * @param extensions File extensions to probe for (useful for testing).
+ * @param mainFields A list of package.json field names to try when resolving module files.
  * @returns the found path, or undefined if no path was found.
  */
 export function matchFromAbsolutePaths(

--- a/test/match-path-async-tests.ts
+++ b/test/match-path-async-tests.ts
@@ -179,6 +179,31 @@ describe("match-path-async", () => {
     );
   });
 
+  it("should resolve from list of fields by priority in package.json", done => {
+    const matchPath = createMatchPathAsync(
+      "/root/",
+      {
+        "lib/*": ["location/*"]
+      },
+      ["missing", "browser", "main"]
+    );
+    const existingPath = join("/root", "location", "mylib", "christoffer.ts");
+    matchPath(
+      "lib/mylib",
+      (_path, callback) =>
+        callback(undefined, {
+          main: "./kalle.ts",
+          browser: "./christoffer.ts"
+        }),
+      (path, callback) => callback(undefined, path === existingPath),
+      undefined,
+      (_err, result) => {
+        assert.equal(result, removeExtension(existingPath), result);
+        done();
+      }
+    );
+  });
+
   it("should resolve to with the help of baseUrl when not explicitly set", done => {
     const matchPath = createMatchPathAsync("/root/", {});
     const existingPath = join("/root", "mylib", "index.ts");

--- a/test/match-path-sync-tests.ts
+++ b/test/match-path-sync-tests.ts
@@ -130,6 +130,24 @@ describe("match-path-sync", () => {
     assert.equal(result, existingPath);
   });
 
+  it("should resolve from list of fields by priority in package.json", () => {
+    const matchPath = createMatchPath("/root/", { "lib/*": ["location/*"] }, [
+      "missing",
+      "browser",
+      "main"
+    ]);
+    const existingPath = join("/root", "location", "mylibjs", "christofferjs");
+    // Make sure we escape the "."
+    const result = matchPath(
+      "lib/mylibjs",
+      (_: string) => ({ main: "./kallejs", browser: "./christofferjs" }),
+      (name: string) => name === existingPath,
+      [".ts", ".js"]
+    );
+
+    assert.equal(result, existingPath);
+  });
+
   it("should resolve to with the help of baseUrl when not explicitly set", () => {
     const matchPath = createMatchPath("/root/", {});
     const existingPath = join("/root", "mylib", "index.ts");


### PR DESCRIPTION
This adds support to provide a list of field names in package.json to try when resolving modules. This is useful when using `tsconfig-path` in other environments than Node, such as Webpack (see [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin) for an example).

This is a required change to tsconfig-paths in an attempt to solve the issue described in: https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/20.

This PR shouldn't affect current usage, as the API still defaults to using "main", as verified by existing test cases.