### PR TITLE
Ignore cwd value based on the project option when exist the require option

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -14,5 +14,5 @@ export interface Options {
 }
 
 export const options: Options = {
-  cwd: project || process.cwd()
+  cwd: (!argv.r && !argv.require && project) || process.cwd()
 };


### PR DESCRIPTION
When use Bootstrap tsconfig-paths with explicit params and use the project option, `cwd` value in `options.ts` use the project option value.

This is a problem when using `absoluteBaseUrl`.

This PR is Ignore `cwd` value based on the project option when exist the require option.