### PR TITLE
Add support for comments and trailing commas

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "deepmerge": "^2.0.1",
+    "json5": "^1.0.1",
     "minimist": "^1.2.0",
-    "strip-bom": "^3.0.0",
-    "strip-json-comments": "^2.0.1"
+    "strip-bom": "^3.0.0"
   },
   "scripts": {
     "start": "cd src && ts-node index.ts",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typescript": "^2.4.1"
   },
   "dependencies": {
+    "@types/json5": "^0.0.29",
     "deepmerge": "^2.0.1",
     "json5": "^1.0.1",
     "minimist": "^1.2.0",

--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -1,9 +1,10 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as deepmerge from "deepmerge";
-import * as StripJsonComments from "strip-json-comments";
-// tslint:disable-next-line:no-require-imports
+// tslint:disable:no-require-imports
+import JSON5 = require("json5");
 import StripBom = require("strip-bom");
+// tslint:enable:no-require-imports
 
 /**
  * Typing for the parts of tsconfig that we care about
@@ -108,8 +109,8 @@ export function loadTsconfig(
   }
 
   const configString = readFileSync(configFilePath);
-  const cleanedJson = StripBom(StripJsonComments(configString));
-  const config: Tsconfig = JSON.parse(cleanedJson);
+  const cleanedJson = StripBom(configString);
+  const config: Tsconfig = JSON5.parse(cleanedJson);
   let extendedConfig = config.extends;
 
   if (extendedConfig) {

--- a/test/tsconfig-loader-tests.ts
+++ b/test/tsconfig-loader-tests.ts
@@ -116,6 +116,20 @@ describe("loadConfig", () => {
     assert.deepEqual(res, config);
   });
 
+  it("It should load a config with trailing commas", () => {
+    const config = { compilerOptions: { baseUrl: "hej" } };
+    const res = loadTsconfig(
+      "/root/dir1/tsconfig.json",
+      path => path === "/root/dir1/tsconfig.json",
+      _ => `{
+          "compilerOptions": { 
+            "baseUrl": "hej",
+          },
+        }`
+    );
+    assert.deepEqual(res, config);
+  });
+
   it("It should load a config with extends and overwrite baseUrl", () => {
     const firstConfig = {
       extends: "../base-config.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,6 +1119,12 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -1945,10 +1951,6 @@ strip-eof@^1.0.0:
 strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-
-strip-json-comments@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 supports-color@5.4.0:
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/deepmerge/-/deepmerge-1.3.2.tgz#a87837384624d63e8c3df3ae85693d574ea6b5db"
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+
 "@types/minimist@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"


### PR DESCRIPTION
* Switch from `JSON.parse` to `JSON5.parse`

resolves dividab/tsconfig-paths#48