### PR TITLE
Prefer Node's core modules over file modules

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -2,6 +2,47 @@ import { createMatchPath } from "./match-path-sync";
 import { configLoader, ExplicitParams } from "./config-loader";
 import { options } from "./options";
 
+function getCoreModules(
+  builtinModules: string[] | undefined
+): { [key: string]: boolean } {
+  builtinModules = builtinModules || [
+    "assert",
+    "buffer",
+    "child_process",
+    "cluster",
+    "crypto",
+    "dgram",
+    "dns",
+    "domain",
+    "events",
+    "fs",
+    "http",
+    "https",
+    "net",
+    "os",
+    "path",
+    "punycode",
+    "querystring",
+    "readline",
+    "stream",
+    "string_decoder",
+    "tls",
+    "tty",
+    "url",
+    "util",
+    "v8",
+    "vm",
+    "zlib"
+  ];
+
+  const coreModules: { [key: string]: boolean } = {};
+  for (let module of builtinModules) {
+    coreModules[module] = true;
+  }
+
+  return coreModules;
+}
+
 /**
  * Installs a custom module load function that can adhere to paths in tsconfig.
  */
@@ -27,13 +68,17 @@ export function register(explicitParams: ExplicitParams): void {
   // tslint:disable-next-line:no-require-imports variable-name
   const Module = require("module");
   const originalResolveFilename = Module._resolveFilename;
+  const coreModules = getCoreModules(Module.builtinModules);
   // tslint:disable-next-line:no-any
   Module._resolveFilename = function(request: string, _parent: any): string {
-    const found = matchPath(request);
-    if (found) {
-      const modifiedArguments = [found, ...[].slice.call(arguments, 1)]; // Passes all arguments. Even those that is not specified above.
-      // tslint:disable-next-line:no-invalid-this
-      return originalResolveFilename.apply(this, modifiedArguments);
+    const isCoreModule = coreModules.hasOwnProperty(request);
+    if (!isCoreModule) {
+      const found = matchPath(request);
+      if (found) {
+        const modifiedArguments = [found, ...[].slice.call(arguments, 1)]; // Passes all arguments. Even those that is not specified above.
+        // tslint:disable-next-line:no-invalid-this
+        return originalResolveFilename.apply(this, modifiedArguments);
+      }
     }
     // tslint:disable-next-line:no-invalid-this
     return originalResolveFilename.apply(this, arguments);


### PR DESCRIPTION
This commit makes this resolver behave like [Node does](https://nodejs.org/api/modules.html#modules_core_modules):
> Core modules are always preferentially loaded if their identifier is passed to `require()`

Additionally this increases performance by avoiding unnecessary disk access. For example `webpack` calls `require("crypto")` in a loop.

This commit fixes #56.