### PR TITLE
add option to avoid adding a match-all rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The public API consists of these functions:
 export interface ExplicitParams {
   baseUrl: string;
   paths: { [key: string]: Array<string> };
+  mainFields?: Array<string>;
+  addMatchAll?: boolean;
 }
 
 /**
@@ -163,12 +165,14 @@ export interface MatchPath {
  * @param absoluteBaseUrl Absolute version of baseUrl as specified in tsconfig.
  * @param paths The paths as specified in tsconfig.
  * @param mainFields A list of package.json field names to try when resolving module files.
+ * @param addMatchAll Add a match-all "*" rule if none is present
  * @returns a function that can resolve paths.
  */
 export function createMatchPath(
   absoluteBaseUrl: string,
   paths: { [key: string]: Array<string> },
-  mainFields: string[] = ["main"]
+  mainFields: string[] = ["main"],
+  addMatchAll: boolean = true
 ): MatchPath {
 ```
 

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -5,6 +5,8 @@ import { options } from "./options";
 export interface ExplicitParams {
   baseUrl: string;
   paths: { [key: string]: Array<string> };
+  mainFields?: Array<string>;
+  addMatchAll?: boolean;
 }
 
 export type TsConfigLoader = (
@@ -23,6 +25,8 @@ export interface ConfigLoaderSuccessResult {
   baseUrl: string;
   absoluteBaseUrl: string;
   paths: { [key: string]: Array<string> };
+  mainFields?: Array<string>;
+  addMatchAll?: boolean;
 }
 
 export interface ConfigLoaderFailResult {
@@ -54,7 +58,9 @@ export function configLoader({
       configFileAbsolutePath: "",
       baseUrl: explicitParams.baseUrl,
       absoluteBaseUrl,
-      paths: explicitParams.paths
+      paths: explicitParams.paths,
+      mainFields: explicitParams.mainFields,
+      addMatchAll: explicitParams.addMatchAll
     };
   }
 

--- a/src/mapping-entry.ts
+++ b/src/mapping-entry.ts
@@ -16,10 +16,12 @@ export interface Paths {
  * sort by keys each time we use the mappings. 
  * @param absoluteBaseUrl 
  * @param paths 
+ * @param addMatchAll 
  */
 export function getAbsoluteMappingEntries(
   absoluteBaseUrl: string,
-  paths: Paths
+  paths: Paths,
+  addMatchAll: boolean
 ): ReadonlyArray<MappingEntry> {
   // Resolve all paths to absolute form once here, and sort them by
   // longest prefix once here, this saves time on each request later.
@@ -34,9 +36,9 @@ export function getAbsoluteMappingEntries(
       )
     });
   }
-  // If there is no match-all path specified in the paths section of tsconfig, then try to match all
-  // all relative to baseUrl, this is how typescript works.
-  if (!paths["*"]) {
+  // If there is no match-all path specified in the paths section of tsconfig, then try to match
+  // all paths relative to baseUrl, this is how typescript works.
+  if (!paths["*"] && addMatchAll) {
     absolutePaths.push({
       pattern: "*",
       paths: [`${absoluteBaseUrl.replace(/\/$/, "")}/*`]

--- a/src/match-path-async.ts
+++ b/src/match-path-async.ts
@@ -26,11 +26,13 @@ export interface MatchPathAsyncCallback {
 export function createMatchPathAsync(
   absoluteBaseUrl: string,
   paths: { [key: string]: Array<string> },
-  mainFields: string[] = ["main"]
+  mainFields: string[] = ["main"],
+  addMatchAll: boolean = true
 ): MatchPathAsync {
   const absolutePaths = MappingEntry.getAbsoluteMappingEntries(
     absoluteBaseUrl,
-    paths
+    paths,
+    addMatchAll
   );
 
   return (

--- a/src/match-path-sync.ts
+++ b/src/match-path-sync.ts
@@ -20,16 +20,19 @@ export interface MatchPath {
  * @param absoluteBaseUrl Absolute version of baseUrl as specified in tsconfig.
  * @param paths The paths as specified in tsconfig.
  * @param mainFields A list of package.json field names to try when resolving module files.
+ * @param addMatchAll Add a match-all "*" rule if none is present
  * @returns a function that can resolve paths.
  */
 export function createMatchPath(
   absoluteBaseUrl: string,
   paths: { [key: string]: Array<string> },
-  mainFields: string[] = ["main"]
+  mainFields: string[] = ["main"],
+  addMatchAll: boolean = true
 ): MatchPath {
   const absolutePaths = MappingEntry.getAbsoluteMappingEntries(
     absoluteBaseUrl,
-    paths
+    paths,
+    addMatchAll
   );
 
   return (

--- a/src/register.ts
+++ b/src/register.ts
@@ -65,7 +65,9 @@ export function register(explicitParams: ExplicitParams): () => void {
 
   const matchPath = createMatchPath(
     configLoaderResult.absoluteBaseUrl,
-    configLoaderResult.paths
+    configLoaderResult.paths,
+    configLoaderResult.mainFields,
+    configLoaderResult.addMatchAll
   );
 
   // Patch node's module loading

--- a/test/data/match-path-data.ts
+++ b/test/data/match-path-data.ts
@@ -8,6 +8,7 @@ export interface OneTest {
   readonly absoluteBaseUrl: string;
   readonly paths: { [key: string]: Array<string> };
   readonly mainFields?: string[];
+  readonly addMatchAll?: boolean;
   readonly existingFiles: ReadonlyArray<string>;
   readonly requestedModule: string;
   readonly extensions?: ReadonlyArray<string>;
@@ -180,6 +181,15 @@ export const tests: ReadonlyArray<OneTest> = [
     existingFiles: [join("/root", "mylib", "index.ts")],
     requestedModule: "mylib",
     expectedPath: dirname(join("/root", "mylib", "index.ts"))
+  },
+  {
+    name: "should not resolve with the help of baseUrl when asked not to",
+    absoluteBaseUrl: "/root/",
+    paths: {},
+    addMatchAll: false,
+    existingFiles: [join("/root", "mylib", "index.ts")],
+    requestedModule: "mylib",
+    expectedPath: undefined
   },
   {
     name: "should not locate path that does not match",

--- a/test/mapping-entry-test.ts
+++ b/test/mapping-entry-test.ts
@@ -4,11 +4,15 @@ import { join } from "path";
 
 describe("mapping-entry", () => {
   it("should change to absolute paths and sort in longest prefix order", () => {
-    const result = getAbsoluteMappingEntries("/absolute/base/url", {
-      "*": ["/foo1", "/foo2"],
-      "longest/pre/fix/*": ["/foo2/bar"],
-      "pre/fix/*": ["/foo3"]
-    });
+    const result = getAbsoluteMappingEntries(
+      "/absolute/base/url",
+      {
+        "*": ["/foo1", "/foo2"],
+        "longest/pre/fix/*": ["/foo2/bar"],
+        "pre/fix/*": ["/foo3"]
+      },
+      true
+    );
     assert.deepEqual(result, [
       {
         pattern: "longest/pre/fix/*",
@@ -26,5 +30,18 @@ describe("mapping-entry", () => {
         ]
       }
     ]);
+  });
+
+  it("should should add a match-all pattern when requested", () => {
+    let result = getAbsoluteMappingEntries("/absolute/base/url", {}, true);
+    assert.deepEqual(result, [
+      {
+        pattern: "*",
+        paths: [join("/absolute", "base", "url", "*")]
+      }
+    ]);
+
+    result = getAbsoluteMappingEntries("/absolute/base/url", {}, false);
+    assert.deepEqual(result, []);
   });
 });

--- a/test/match-path-async-tests.ts
+++ b/test/match-path-async-tests.ts
@@ -8,7 +8,8 @@ describe("match-path-async", () => {
       const matchPath = createMatchPathAsync(
         t.absoluteBaseUrl,
         t.paths,
-        t.mainFields
+        t.mainFields,
+        t.addMatchAll
       );
       matchPath(
         t.requestedModule,

--- a/test/match-path-sync-tests.ts
+++ b/test/match-path-sync-tests.ts
@@ -8,7 +8,8 @@ describe("match-path-sync", () => {
       const matchPath = createMatchPath(
         t.absoluteBaseUrl,
         t.paths,
-        t.mainFields
+        t.mainFields,
+        t.addMatchAll
       );
       const result = matchPath(
         t.requestedModule,


### PR DESCRIPTION
this solves part of #72 

Also makes `mainFields` configurable when using `register`.
The naming is open to bikeshedding…