### PR TITLE
adding option matchAfterOriginal

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ export interface ExplicitParams {
   paths: { [key: string]: Array<string> };
   mainFields?: Array<string>;
   addMatchAll?: boolean;
+  matchAfterOriginal?: boolean;
 }
 
 /**

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -7,6 +7,7 @@ export interface ExplicitParams {
   paths: { [key: string]: Array<string> };
   mainFields?: Array<string>;
   addMatchAll?: boolean;
+  matchAfterOriginal?: boolean;
 }
 
 export type TsConfigLoader = (
@@ -27,6 +28,7 @@ export interface ConfigLoaderSuccessResult {
   paths: { [key: string]: Array<string> };
   mainFields?: Array<string>;
   addMatchAll?: boolean;
+  matchAfterOriginal?: boolean;
 }
 
 export interface ConfigLoaderFailResult {
@@ -60,7 +62,8 @@ export function configLoader({
       absoluteBaseUrl,
       paths: explicitParams.paths,
       mainFields: explicitParams.mainFields,
-      addMatchAll: explicitParams.addMatchAll
+      addMatchAll: explicitParams.addMatchAll,
+      matchAfterOriginal: explicitParams.matchAfterOriginal
     };
   }
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -79,6 +79,21 @@ export function register(explicitParams: ExplicitParams): () => void {
   Module._resolveFilename = function(request: string, _parent: any): string {
     const isCoreModule = coreModules.hasOwnProperty(request);
     if (!isCoreModule) {
+      if (configLoaderResult.matchAfterOriginal) {
+        let originalFound;
+
+        try {
+          // tslint:disable-next-line:no-invalid-this
+          originalFound = originalResolveFilename.apply(this, arguments);
+        } catch (e) {
+          // noop
+        }
+
+        if (originalFound) {
+          return originalFound;
+        }
+      }
+
       const found = matchPath(request);
       if (found) {
         const modifiedArguments = [found, ...[].slice.call(arguments, 1)]; // Passes all arguments. Even those that is not specified above.


### PR DESCRIPTION
allow to use tsconfig-paths only if the module was not found using the default resolve function
fixes #15 and #66 