### PR TITLE
[DOCS] Mention ability to pass the tsconfig directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ export interface ConfigLoaderFailResult {
 }
 ```
 
-This function loads the tsconfig.json. It will start searching from the specified `cwd` directory.
+This function loads the tsconfig.json. It will start searching from the specified `cwd` directory. Passing the tsconfig.json file directly instead of a directory also works.
 
 ### createMatchPath
 


### PR DESCRIPTION
This functionality was implemented in #32
Direct reference:
https://github.com/dividab/tsconfig-paths/blob/47d729b39b8b2b75cb652c6a0c2d272e166764ec/src/tsconfig-loader.ts#L74-L76