### PR TITLE
feat(tsconfig-loader): extends config from node_modules

### DIFF
--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -120,14 +120,22 @@ export function loadTsconfig(
     ) {
       extendedConfig += ".json";
     }
-
     const currentDir = path.dirname(configFilePath);
+    let extendedConfigPath = path.join(currentDir, extendedConfig);
+    if (
+      extendedConfig.indexOf("/") !== -1 &&
+      extendedConfig.indexOf(".") !== -1 &&
+      !existsSync(extendedConfigPath)
+    ) {
+      extendedConfigPath = path.join(
+        currentDir,
+        "node_modules",
+        extendedConfig
+      );
+    }
+
     const base =
-      loadTsconfig(
-        path.join(currentDir, extendedConfig),
-        existsSync,
-        readFileSync
-      ) || {};
+      loadTsconfig(extendedConfigPath, existsSync, readFileSync) || {};
 
     // baseUrl should be interpreted as relative to the base tsconfig,
     // but we need to update it so it is relative to the original tsconfig being loaded

--- a/test/tsconfig-loader-tests.ts
+++ b/test/tsconfig-loader-tests.ts
@@ -168,6 +168,50 @@ describe("loadConfig", () => {
     });
   });
 
+  it("It should load a config with extends from node_modules and overwrite all options", () => {
+    const firstConfig = {
+      extends: "my-package/base-config.json",
+      compilerOptions: { baseUrl: "kalle", paths: { foo: ["bar2"] } }
+    };
+    const firstConfigPath = join("/root", "dir1", "tsconfig.json");
+    const baseConfig = {
+      compilerOptions: {
+        baseUrl: "olle",
+        paths: { foo: ["bar1"] },
+        strict: true
+      }
+    };
+    const baseConfigPath = join(
+      "/root",
+      "dir1",
+      "node_modules",
+      "my-package",
+      "base-config.json"
+    );
+    const res = loadTsconfig(
+      join("/root", "dir1", "tsconfig.json"),
+      path => path === firstConfigPath || path === baseConfigPath,
+      path => {
+        if (path === firstConfigPath) {
+          return JSON.stringify(firstConfig);
+        }
+        if (path === baseConfigPath) {
+          return JSON.stringify(baseConfig);
+        }
+        return "";
+      }
+    );
+
+    assert.deepEqual(res, {
+      extends: "my-package/base-config.json",
+      compilerOptions: {
+        baseUrl: "kalle",
+        paths: { foo: ["bar2"] },
+        strict: true
+      }
+    });
+  });
+
   it("Should use baseUrl relative to location of extended tsconfig", () => {
     const firstConfig = { compilerOptions: { baseUrl: "." } };
     const firstConfigPath = join("/root", "first-config.json");


### PR DESCRIPTION
At the moment, when an extends path is specific, the extends path has to be relative to the overriding `tsconfig.json` file.

However, in the implementation of `tsc --showConfig`, it also supports search from `node_modules` in the same current directory.

e.g.

If a base file exists in `node_modules/my-package/tsconfig.base.json`.

Both

```
{
  "extends": "./node_modules/my-package/tsconfig.base.json"
}
```

and 

```
{
  "extends": "my-package/tsconfig.base.json"
}
```

have the same effect.

Because `tsc` behaves like this, `tsconfig-paths` should be consistent.