### PR TITLE
Update .npmignore to ignore tests and json files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 .idea/
 src/
-tests/
+test/
 example/
 custom-typings/
 scripts/
@@ -14,3 +14,5 @@ coverage/
 .nyc_output/
 coverage.lcov
 .travis.yml
+.nycrc.json
+tslint.json


### PR DESCRIPTION
Seems the `.npmignore` was targeting `tests` instead of `test` - maybe the folder name was changed at some point? 🤷‍♂ 

I've also added `tslint.json` & `.nycrc.json` as they're also not needed in the published package :)