### PR TITLE
Add support for baseUrl overwrite using TS_NODE_BASEURL environment v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ npm install --save-dev tsconfig-paths
 
 `node -r tsconfig-paths/register main.js`
 
+If `process.env.TS_NODE_BASEURL` is set it will be overwrite the value of baseUrl in tsconfig.json:
+
+`TS_NODE_BASEURL=./dist node -r tsconfig-paths/register main.js`
+
 ### With ts-node
 
 `ts-node -r tsconfig-paths/register main.ts`

--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -26,7 +26,11 @@ export interface TsConfigLoaderResult {
 export interface TsConfigLoaderParams {
   getEnv: (key: string) => string | undefined;
   cwd: string;
-  loadSync?(cwd: string, filename?: string): TsConfigLoaderResult;
+  loadSync?(
+    cwd: string,
+    filename?: string,
+    baseUrl?: string
+  ): TsConfigLoaderResult;
 }
 
 export function tsConfigLoader({
@@ -35,13 +39,18 @@ export function tsConfigLoader({
   loadSync = loadSyncDefault
 }: TsConfigLoaderParams): TsConfigLoaderResult {
   const TS_NODE_PROJECT = getEnv("TS_NODE_PROJECT");
+  const TS_NODE_BASEURL = getEnv("TS_NODE_BASEURL");
 
   // tsconfig.loadSync handles if TS_NODE_PROJECT is a file or directory
-  const loadResult = loadSync(cwd, TS_NODE_PROJECT);
+  const loadResult = loadSync(cwd, TS_NODE_PROJECT, TS_NODE_BASEURL);
   return loadResult;
 }
 
-function loadSyncDefault(cwd: string, filename?: string): TsConfigLoaderResult {
+function loadSyncDefault(
+  cwd: string,
+  filename?: string,
+  baseUrl?: string
+): TsConfigLoaderResult {
   // Tsconfig.loadSync uses path.resolve. This is why we can use an absolute path as filename
 
   const configPath = resolveConfigPath(cwd, filename);
@@ -57,7 +66,9 @@ function loadSyncDefault(cwd: string, filename?: string): TsConfigLoaderResult {
 
   return {
     tsConfigPath: configPath,
-    baseUrl: config && config.compilerOptions && config.compilerOptions.baseUrl,
+    baseUrl: baseUrl
+      ? baseUrl
+      : config && config.compilerOptions && config.compilerOptions.baseUrl,
     paths: config && config.compilerOptions && config.compilerOptions.paths
   };
 }

--- a/test/tsconfig-loader-tests.ts
+++ b/test/tsconfig-loader-tests.ts
@@ -65,6 +65,41 @@ describe("tsconfig-loader", () => {
   });
 });
 
+it("should use TS_NODE_BASEURL env if exists", () => {
+  const result = tsConfigLoader({
+    cwd: "/foo/bar",
+    getEnv: (key: string) =>
+      key === "TS_NODE_BASEURL" ? "SOME_BASEURL" : undefined,
+    loadSync: (cwd: string, fileName: string, baseUrl: string) => {
+      return {
+        tsConfigPath: undefined,
+        baseUrl,
+        paths: {}
+      };
+    }
+  });
+
+  assert.equal(result.baseUrl, "SOME_BASEURL");
+});
+
+it("should not use TS_NODE_BASEURL env if it does not exist", () => {
+  const result = tsConfigLoader({
+    cwd: "/foo/bar",
+    getEnv: (key: string) => {
+      return undefined;
+    },
+    loadSync: (cwd: string, fileName: string, baseUrl: string) => {
+      return {
+        tsConfigPath: undefined,
+        baseUrl,
+        paths: {}
+      };
+    }
+  });
+
+  assert.equal(result.baseUrl, undefined);
+});
+
 describe("walkForTsConfig", () => {
   it("should find tsconfig in starting directory", () => {
     const pathToTsconfig = join("/root", "dir1", "tsconfig.json");


### PR DESCRIPTION
Adds support for baseUrl overwrite using `TS_NODE_BASEURL` environment variable.

First off, thanks for this library! It seems that several people are running into a case where they need to change the `baseUrl` to get this working after running `tsc`. So far most of the solutions look to be either:

1) Creating a bootstrap js file for the sole purpose of changing `baseUrl`
2) Extending `tsconfig.json` to extend the orginal `tsconfig.json` and then set `baseUrl` based on that

It seems like the simplest solution would be to allow changing the baseUrl via environment variable instead of either of the above options.