### PR TITLE
correctly strip .d.ts file extensions

### DIFF
--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -1,12 +1,15 @@
 import * as path from "path";
 import { MappingEntry } from "./mapping-entry";
 import { dirname } from "path";
-import { removeExtension } from "./filesystem";
 
-export interface TryPath {
-  readonly type: "file" | "extension" | "index" | "package";
+export type TryPath = {
+  readonly type: "file" | "index" | "package";
   readonly path: string;
-}
+} | {
+  readonly type: "extension";
+  readonly path: string;
+  readonly extensionLength: number;
+};
 
 /**
  * Builds a list of all physical paths to try by:
@@ -41,7 +44,7 @@ export function getPathsToTry(
         pathsToTry.push({ type: "file", path: physicalPath });
         pathsToTry.push(
           ...extensions.map(
-            e => ({ type: "extension", path: physicalPath + e } as TryPath)
+            e => ({ type: "extension", path: physicalPath + e, extensionLength: e.length } as TryPath)
           )
         );
         pathsToTry.push({
@@ -67,7 +70,7 @@ export function getStrippedPath(tryPath: TryPath): string {
     : tryPath.type === "file"
       ? tryPath.path
       : tryPath.type === "extension"
-        ? removeExtension(tryPath.path)
+        ? tryPath.path.slice(0, -tryPath.extensionLength)
         : tryPath.type === "package"
           ? tryPath.path
           : exhaustiveTypeException(tryPath.type);
@@ -80,7 +83,7 @@ export function exhaustiveTypeException(check: never): never {
 /**
  * Matches pattern with a single star against search.
  * Star must match at least one character to be considered a match.
- * @param patttern for example "foo*" 
+ * @param patttern for example "foo*"
  * @param search for example "fooawesomebar"
  * @returns the part of search that * matches, or undefined if no match.
  */


### PR DESCRIPTION
`removeExtension` strips extension by looking for the last `.`. This does not work for definition files, `.d.ts`. I include the length of the extension and strip using that information.