### PR TITLE
fix: regard file extensions from package.json during path resolution (#133)

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -81,7 +81,3 @@ export function fileExistsAsync(
     callback2(undefined, stats ? stats.isFile() : false);
   });
 }
-
-export function removeExtension(path: string): string {
-  return path.substring(0, path.lastIndexOf(".")) || path;
-}

--- a/src/match-path-async.ts
+++ b/src/match-path-async.ts
@@ -148,7 +148,6 @@ function findFirstExistingPath(
         return doneCallback(err);
       }
       if (exists) {
-        // Not sure why we don't just return the full path? Why strip it?
         return doneCallback(undefined, TryPath.getStrippedPath(tryPath));
       }
       if (index === tryPaths.length - 1) {
@@ -180,11 +179,7 @@ function findFirstExistingPath(
               return doneCallback(mainFieldErr);
             }
             if (mainFieldMappedFile) {
-              // Not sure why we don't just return the full path? Why strip it?
-              return doneCallback(
-                undefined,
-                Filesystem.removeExtension(mainFieldMappedFile)
-              );
+              return doneCallback(undefined, mainFieldMappedFile);
             }
 
             // No field in package json was a valid option. Continue with the next path.

--- a/src/match-path-sync.ts
+++ b/src/match-path-sync.ts
@@ -118,7 +118,6 @@ function findFirstExistingPath(
       tryPath.type === "index"
     ) {
       if (fileExists(tryPath.path)) {
-        // Not sure why we don't just return the full path? Why strip it?
         return TryPath.getStrippedPath(tryPath);
       }
     } else if (tryPath.type === "package") {
@@ -131,8 +130,7 @@ function findFirstExistingPath(
           fileExists
         );
         if (mainFieldMappedFile) {
-          // Not sure why we don't just return the full path? Why strip it?
-          return Filesystem.removeExtension(mainFieldMappedFile);
+          return mainFieldMappedFile;
         }
       }
     } else {

--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import { MappingEntry } from "./mapping-entry";
 import { dirname } from "path";
-import { removeExtension } from "./filesystem";
 
 export interface TryPath {
   readonly type: "file" | "extension" | "index" | "package";
@@ -60,15 +59,12 @@ export function getPathsToTry(
   return pathsToTry.length === 0 ? undefined : pathsToTry;
 }
 
-// Not sure why we don't just return the full found path?
 export function getStrippedPath(tryPath: TryPath): string {
   return tryPath.type === "index"
     ? dirname(tryPath.path)
-    : tryPath.type === "file"
-    ? tryPath.path
-    : tryPath.type === "extension"
-    ? removeExtension(tryPath.path)
-    : tryPath.type === "package"
+    : tryPath.type === "file" ||
+      tryPath.type === "extension" ||
+      tryPath.type === "package"
     ? tryPath.path
     : exhaustiveTypeException(tryPath.type);
 }

--- a/test/data/match-path-data.ts
+++ b/test/data/match-path-data.ts
@@ -1,5 +1,4 @@
 import { join, dirname } from "path";
-import { removeExtension } from "../../src/filesystem";
 
 export interface OneTest {
   readonly name: string;
@@ -60,7 +59,7 @@ export const tests: ReadonlyArray<OneTest> = [
     existingFiles: [join("/root", "location", "mylib.myext")],
     requestedModule: "lib/mylib",
     extensions: [".js", ".myext"],
-    expectedPath: removeExtension(join("/root", "location", "mylib.myext")),
+    expectedPath: join("/root", "location", "mylib.myext"),
   },
   {
     name: "should resolve request with extension specified",
@@ -78,7 +77,7 @@ export const tests: ReadonlyArray<OneTest> = [
     },
     existingFiles: [join("/root", "location", "foo.ts")],
     requestedModule: "lib/foo",
-    expectedPath: removeExtension(join("/root", "location", "foo.ts")),
+    expectedPath: join("/root", "location", "foo.ts"),
   },
   {
     name: "should resolve to parent folder when filename is in subfolder",
@@ -95,9 +94,7 @@ export const tests: ReadonlyArray<OneTest> = [
     existingFiles: [join("/root", "location", "mylib", "kalle.ts")],
     packageJson: { main: "./kalle.ts" },
     requestedModule: "lib/mylib",
-    expectedPath: removeExtension(
-      join("/root", "location", "mylib", "kalle.ts")
-    ),
+    expectedPath: join("/root", "location", "mylib", "kalle.ts"),
   },
   {
     name: "should resolve from main field in package.json (js)",
@@ -107,9 +104,7 @@ export const tests: ReadonlyArray<OneTest> = [
     packageJson: { main: "./kalle.js" },
     requestedModule: "lib/mylib.js",
     extensions: [".ts", ".js"],
-    expectedPath: removeExtension(
-      join("/root", "location", "mylib.js", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylib.js", "kalle.js"),
   },
   {
     name:
@@ -120,9 +115,7 @@ export const tests: ReadonlyArray<OneTest> = [
     packageJson: { main: "./kalle.js" },
     extensions: [".ts", ".js"],
     requestedModule: "lib/mylibjs",
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "kalle.js"),
   },
   {
     name: "should resolve from list of fields by priority in package.json",
@@ -136,9 +129,7 @@ export const tests: ReadonlyArray<OneTest> = [
     ],
     extensions: [".ts", ".js"],
     requestedModule: "lib/mylibjs",
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "browser.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "browser.js"),
   },
   {
     name: "should ignore field mappings to missing files in package.json",
@@ -152,9 +143,7 @@ export const tests: ReadonlyArray<OneTest> = [
       browser: "./nope.js",
     },
     extensions: [".ts", ".js"],
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "kalle.js"),
   },
   {
     name: "should ignore advanced field mappings in package.json",
@@ -170,9 +159,7 @@ export const tests: ReadonlyArray<OneTest> = [
       browser: { mylibjs: "./browser.js", "./kalle.js": "./browser.js" },
     },
     extensions: [".ts", ".js"],
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "kalle.js"),
   },
   {
     name: "should resolve to with the help of baseUrl when not explicitly set",
@@ -208,5 +195,16 @@ export const tests: ReadonlyArray<OneTest> = [
     existingFiles: [join("/root", "location", "mylib", "index.d.ts")],
     requestedModule: "lib/mylib",
     expectedPath: undefined,
+  },
+  {
+    name: "should resolve main file with cjs file extension",
+    absoluteBaseUrl: "/root/",
+    paths: {},
+    existingFiles: [join("/root", "mylib", "index.cjs")],
+    packageJson: {
+      main: "./index.cjs",
+    },
+    requestedModule: "mylib",
+    expectedPath: join("/root", "mylib", "index.cjs"),
   },
 ];


### PR DESCRIPTION
- Related to the comment from @jonaskello https://github.com/dividab/tsconfig-paths/issues/133#issuecomment-663238382
- Adds support for cjs main entries by considering file extensions during path resolution
  - I added an extra test for the cjs main entry
  - Also tried out the new build with my original colorette cjs error reproduction zip from #133