### PR TITLE
match the string between part 1 and part 2

### DIFF
--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -103,5 +103,5 @@ function matchStar(pattern: string, search: string): string | undefined {
   if (search.substr(search.length - part2.length) !== part2) {
     return undefined;
   }
-  return search.substr(star, search.length - part2.length);
+  return search.substring(star, search.length - part2.length);
 }


### PR DESCRIPTION
The * should match everything between two paths. Instead, it was matching a certain number of characters.
Closes #140 