### PR TITLE
Add node.js register file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ npm install --save-dev tsconfig-paths
 
 `node -r tsconfig-paths/register main.js`
 
+if you configure tsconfig outDir it reedirect output structure to another direcotry you can use it this way
+
+`node -r tsconfig-paths/node dist/main.js`
+
 ### With ts-node
 
 `ts-node -r tsconfig-paths/register main.ts`

--- a/node.js
+++ b/node.js
@@ -1,0 +1,17 @@
+const { register } = require("./lib/register");
+const { options } = require("./lib/options");
+const { tsConfigLoader } = require("./lib/tsconfig-loader");
+const path = require("path");
+
+const tsConfig = tsConfigLoader({
+  cwd: options.cwd,
+  getEnv: function (key) {
+    return process.env[key];
+  },
+});
+const baseUrl = path.join(tsConfig.outDir, tsConfig.baseUrl);
+
+register({
+  baseUrl,
+  paths: tsConfig.paths,
+});

--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -21,6 +21,7 @@ export interface Tsconfig {
 export interface TsConfigLoaderResult {
   tsConfigPath: string | undefined;
   baseUrl: string | undefined;
+  outDir: string | undefined;
   paths: { [key: string]: Array<string> } | undefined;
 }
 
@@ -52,6 +53,7 @@ function loadSyncDefault(cwd: string, filename?: string): TsConfigLoaderResult {
       tsConfigPath: undefined,
       baseUrl: undefined,
       paths: undefined,
+      outDir: undefined,
     };
   }
   const config = loadTsconfig(configPath);

--- a/src/tsconfig-loader.ts
+++ b/src/tsconfig-loader.ts
@@ -12,6 +12,7 @@ export interface Tsconfig {
   extends?: string;
   compilerOptions?: {
     baseUrl?: string;
+    outDir?: string;
     paths?: { [key: string]: Array<string> };
     strict?: boolean;
   };
@@ -57,6 +58,7 @@ function loadSyncDefault(cwd: string, filename?: string): TsConfigLoaderResult {
 
   return {
     tsConfigPath: configPath,
+    outDir: config && config.compilerOptions && config.compilerOptions.outDir,
     baseUrl: config && config.compilerOptions && config.compilerOptions.baseUrl,
     paths: config && config.compilerOptions && config.compilerOptions.paths,
   };

--- a/test/config-loader-tests.ts
+++ b/test/config-loader-tests.ts
@@ -50,6 +50,7 @@ describe("config-loader", (): void => {
         tsConfigPath: "/baz/tsconfig.json",
         baseUrl: "./src",
         paths: {},
+        outDir: undefined,
       }),
     });
 
@@ -67,6 +68,7 @@ describe("config-loader", (): void => {
         tsConfigPath: "/baz/tsconfig.json",
         baseUrl: undefined,
         paths: {},
+        outDir: undefined,
       }),
     });
 

--- a/test/tsconfig-loader-tests.ts
+++ b/test/tsconfig-loader-tests.ts
@@ -16,6 +16,7 @@ describe("tsconfig-loader", () => {
           tsConfigPath: `${cwd}/tsconfig.json`,
           baseUrl: "./",
           paths: {},
+          outDir: undefined,
         };
       },
     });
@@ -32,6 +33,7 @@ describe("tsconfig-loader", () => {
           tsConfigPath: undefined,
           baseUrl: "./",
           paths: {},
+          outDir: undefined,
         };
       },
     });
@@ -50,6 +52,7 @@ describe("tsconfig-loader", () => {
             tsConfigPath: "/foo/baz/tsconfig.json",
             baseUrl: "./",
             paths: {},
+            outDir: undefined,
           };
         }
 
@@ -57,6 +60,7 @@ describe("tsconfig-loader", () => {
           tsConfigPath: undefined,
           baseUrl: "./",
           paths: {},
+          outDir: undefined,
         };
       },
     });


### PR DESCRIPTION
it will load tsconfig and set the baseUrl to outDir + baseUrl

I think this pull request can close this issue https://github.com/dividab/tsconfig-paths/issues/61 

at least lots of people that use typescript to write node.js they set the `outDir` property.