### PR TITLE
Added support for absolute paths

### DIFF
--- a/src/mapping-entry.ts
+++ b/src/mapping-entry.ts
@@ -1,12 +1,12 @@
 import * as path from "path";
 
 export interface MappingEntry {
-  readonly pattern: string;
-  readonly paths: ReadonlyArray<string>;
+	readonly pattern: string;
+	readonly paths: ReadonlyArray<string>;
 }
 
 export interface Paths {
-  readonly [key: string]: ReadonlyArray<string>;
+	readonly [key: string]: ReadonlyArray<string>;
 }
 
 /**
@@ -18,34 +18,28 @@ export interface Paths {
  * @param paths
  * @param addMatchAll
  */
-export function getAbsoluteMappingEntries(
-  absoluteBaseUrl: string,
-  paths: Paths,
-  addMatchAll: boolean
-): ReadonlyArray<MappingEntry> {
-  // Resolve all paths to absolute form once here, and sort them by
-  // longest prefix once here, this saves time on each request later.
-  // We need to put them in an array to preserve the sorting order.
-  const sortedKeys = sortByLongestPrefix(Object.keys(paths));
-  const absolutePaths: Array<MappingEntry> = [];
-  for (const key of sortedKeys) {
-    absolutePaths.push({
-      pattern: key,
-      paths: paths[key].map((pathToResolve) =>
-        path.join(absoluteBaseUrl, pathToResolve)
-      ),
-    });
-  }
-  // If there is no match-all path specified in the paths section of tsconfig, then try to match
-  // all paths relative to baseUrl, this is how typescript works.
-  if (!paths["*"] && addMatchAll) {
-    absolutePaths.push({
-      pattern: "*",
-      paths: [`${absoluteBaseUrl.replace(/\/$/, "")}/*`],
-    });
-  }
+export function getAbsoluteMappingEntries(absoluteBaseUrl: string, paths: Paths, addMatchAll: boolean): ReadonlyArray<MappingEntry> {
+	// Resolve all paths to absolute form once here, and sort them by
+	// longest prefix once here, this saves time on each request later.
+	// We need to put them in an array to preserve the sorting order.
+	const sortedKeys = sortByLongestPrefix(Object.keys(paths));
+	const absolutePaths: Array<MappingEntry> = [];
+	for (const key of sortedKeys) {
+		absolutePaths.push({
+			pattern: key,
+			paths: paths[key].map((pathToResolve) => (path.isAbsolute(pathToResolve) ? pathToResolve : path.join(absoluteBaseUrl, pathToResolve))),
+		});
+	}
+	// If there is no match-all path specified in the paths section of tsconfig, then try to match
+	// all paths relative to baseUrl, this is how typescript works.
+	if (!paths["*"] && addMatchAll) {
+		absolutePaths.push({
+			pattern: "*",
+			paths: [`${absoluteBaseUrl.replace(/\/$/, "")}/*`],
+		});
+	}
 
-  return absolutePaths;
+	return absolutePaths;
 }
 
 /**
@@ -53,12 +47,10 @@ export function getAbsoluteMappingEntries(
  * If a module name can be matched with multiple patterns then pattern with the longest prefix will be picked.
  */
 function sortByLongestPrefix(arr: Array<string>): Array<string> {
-  return arr
-    .concat()
-    .sort((a: string, b: string) => getPrefixLength(b) - getPrefixLength(a));
+	return arr.concat().sort((a: string, b: string) => getPrefixLength(b) - getPrefixLength(a));
 }
 
 function getPrefixLength(pattern: string): number {
-  const prefixLength = pattern.indexOf("*");
-  return pattern.substr(0, prefixLength).length;
+	const prefixLength = pattern.indexOf("*");
+	return pattern.substr(0, prefixLength).length;
 }

--- a/test/mapping-entry-test.ts
+++ b/test/mapping-entry-test.ts
@@ -3,45 +3,63 @@ import { getAbsoluteMappingEntries } from "../src/mapping-entry";
 import { join } from "path";
 
 describe("mapping-entry", () => {
-  it("should change to absolute paths and sort in longest prefix order", () => {
-    const result = getAbsoluteMappingEntries(
-      "/absolute/base/url",
-      {
-        "*": ["/foo1", "/foo2"],
-        "longest/pre/fix/*": ["/foo2/bar"],
-        "pre/fix/*": ["/foo3"],
-      },
-      true
-    );
-    assert.deepEqual(result, [
-      {
-        pattern: "longest/pre/fix/*",
-        paths: [join("/absolute", "base", "url", "foo2", "bar")],
-      },
-      {
-        pattern: "pre/fix/*",
-        paths: [join("/absolute", "base", "url", "foo3")],
-      },
-      {
-        pattern: "*",
-        paths: [
-          join("/absolute", "base", "url", "foo1"),
-          join("/absolute", "base", "url", "foo2"),
-        ],
-      },
-    ]);
-  });
+	it("should change to absolute paths and sort in longest prefix order", () => {
+		const result = getAbsoluteMappingEntries(
+			"/absolute/base/url",
+			{
+				"*": ["foo1", "foo2"],
+				"longest/pre/fix/*": ["foo2/bar"],
+				"pre/fix/*": ["foo3"],
+			},
+			true
+		);
+		assert.deepEqual(result, [
+			{
+				pattern: "longest/pre/fix/*",
+				paths: [join("/absolute", "base", "url", "foo2", "bar")],
+			},
+			{
+				pattern: "pre/fix/*",
+				paths: [join("/absolute", "base", "url", "foo3")],
+			},
+			{
+				pattern: "*",
+				paths: [join("/absolute", "base", "url", "foo1"), join("/absolute", "base", "url", "foo2")],
+			},
+		]);
+	});
 
-  it("should should add a match-all pattern when requested", () => {
-    let result = getAbsoluteMappingEntries("/absolute/base/url", {}, true);
-    assert.deepEqual(result, [
-      {
-        pattern: "*",
-        paths: [join("/absolute", "base", "url", "*")],
-      },
-    ]);
+	it("should change to absolute paths and sort in longest prefix order, but avoid already absolute paths", () => {
+		const result = getAbsoluteMappingEntries(
+			"/absolute/base/url",
+			{
+				"pre/fix/*": ["foo3"],
+				"pre/fix2/*": ["/absolute_path/foo3"],
+			},
+			false
+		);
+		assert.deepEqual(result, [
+			{
+				pattern: "pre/fix2/*",
+				paths: [join("/absolute_path", "foo3")],
+			},
+			{
+				pattern: "pre/fix/*",
+				paths: [join("/absolute", "base", "url", "foo3")],
+			},
+		]);
+	});
 
-    result = getAbsoluteMappingEntries("/absolute/base/url", {}, false);
-    assert.deepEqual(result, []);
-  });
+	it("should should add a match-all pattern when requested", () => {
+		let result = getAbsoluteMappingEntries("/absolute/base/url", {}, true);
+		assert.deepEqual(result, [
+			{
+				pattern: "*",
+				paths: [join("/absolute", "base", "url", "*")],
+			},
+		]);
+
+		result = getAbsoluteMappingEntries("/absolute/base/url", {}, false);
+		assert.deepEqual(result, []);
+	});
 });


### PR DESCRIPTION
tsconfig-paths doesn't follow regular `paths` resolution (#101)
I can provide a minimal repo, but nevertheless, `tsc` will not append `baseUrl` to the path mapping that is absolute

This change is "breaking" change for someone that was using absolute mappings, but as the absolute mappings were not working as expected, it is not highly likely that it will really break anyone's code.

Still, there might be a good idea to make it possible to enable the legacy mode (I can extend the PR) or, even keep the legacy mode as default (since I think the current mode is a bug, I suggest against this idea if possible?)