### PR TITLE
Add file extenstion to typings property value

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.9.0",
   "description": "Load node modules according to tsconfig paths, in run-time or via API.",
   "main": "lib/index.js",
-  "types": "lib/index",
+  "types": "lib/index.d.ts",
   "author": "Jonas Kello",
   "license": "MIT",
   "repository": "https://github.com/dividab/tsconfig-paths",


### PR DESCRIPTION
TypeScript requires the file extension be specified in typings / types property. https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html