### PR TITLE
Memoize module resolution

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -69,6 +69,7 @@ export function register(explicitParams: ExplicitParams): () => void {
     configLoaderResult.mainFields,
     configLoaderResult.addMatchAll
   );
+  const matchPathCache: Record<string, string | undefined> = {};
 
   // Patch node's module loading
   // tslint:disable-next-line:no-require-imports variable-name
@@ -79,7 +80,10 @@ export function register(explicitParams: ExplicitParams): () => void {
   Module._resolveFilename = function (request: string, _parent: any): string {
     const isCoreModule = coreModules.hasOwnProperty(request);
     if (!isCoreModule) {
-      const found = matchPath(request);
+      if (!(request in matchPathCache)) {
+        matchPathCache[request] = matchPath(request);
+      }
+      const found = matchPathCache[request];
       if (found) {
         const modifiedArguments = [found, ...[].slice.call(arguments, 1)]; // Passes all arguments. Even those that is not specified above.
         // tslint:disable-next-line:no-invalid-this


### PR DESCRIPTION
In a large codebase, `tsconfig-paths` starts to introduce performance issues as many modules need to be loaded. In https://github.com/dividab/tsconfig-paths/issues/72#issuecomment-472659666, @BJChen990 suggested introducing a cache to avoid hitting the filesystem multiple times for the same path. For me, this resulted in a ~50% speedup.