### PR TITLE
fix: regard file extensions during path resolution (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Include file extension in paths resolved from package.json "main" field. See PR [#135](https://github.com/dividab/tsconfig-paths/pull/135) and issue [#133](https://github.com/dividab/tsconfig-paths/issues/133).  Thanks to [@katywings](https://github.com/katywings) for this fix!
+
 ## [3.12.0] - 2021-08-24
 
 - Add support for baseUrl override using TS_NODE_BASEURL env var #185 and #114. Thanks to @ejhayes and @information-security for these PRs!

--- a/src/__tests__/data/match-path-data.ts
+++ b/src/__tests__/data/match-path-data.ts
@@ -108,9 +108,7 @@ export const tests: ReadonlyArray<OneTest> = [
     existingFiles: [join("/root", "location", "mylib", "kalle.ts")],
     packageJson: { main: "./kalle.ts" },
     requestedModule: "lib/mylib",
-    expectedPath: removeExtension(
-      join("/root", "location", "mylib", "kalle.ts")
-    ),
+    expectedPath: join("/root", "location", "mylib", "kalle.ts"),
     extensions: defaultExtensionsWhenRunningInTsNode,
   },
   {
@@ -121,22 +119,7 @@ export const tests: ReadonlyArray<OneTest> = [
     packageJson: { main: "./kalle.js" },
     requestedModule: "lib/mylib.js",
     extensions: [".ts", ".js"],
-    expectedPath: removeExtension(
-      join("/root", "location", "mylib.js", "kalle.js")
-    ),
-  },
-  {
-    name:
-      "should resolve from main field in package.json and correctly remove file extension",
-    absoluteBaseUrl: "/root/",
-    paths: { "lib/*": ["location/*"] },
-    existingFiles: [join("/root", "location", "mylibjs", "kalle.js")],
-    packageJson: { main: "./kalle.js" },
-    extensions: [".ts", ".js"],
-    requestedModule: "lib/mylibjs",
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylib.js", "kalle.js"),
   },
   {
     name: "should resolve from list of fields by priority in package.json",
@@ -150,9 +133,7 @@ export const tests: ReadonlyArray<OneTest> = [
     ],
     extensions: [".ts", ".js"],
     requestedModule: "lib/mylibjs",
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "browser.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "browser.js"),
   },
   {
     name: "should ignore field mappings to missing files in package.json",
@@ -166,9 +147,7 @@ export const tests: ReadonlyArray<OneTest> = [
       browser: "./nope.js",
     },
     extensions: [".ts", ".js"],
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "kalle.js"),
   },
   {
     name: "should ignore advanced field mappings in package.json",
@@ -184,9 +163,7 @@ export const tests: ReadonlyArray<OneTest> = [
       browser: { mylibjs: "./browser.js", "./kalle.js": "./browser.js" },
     },
     extensions: [".ts", ".js"],
-    expectedPath: removeExtension(
-      join("/root", "location", "mylibjs", "kalle.js")
-    ),
+    expectedPath: join("/root", "location", "mylibjs", "kalle.js"),
   },
   {
     name: "should resolve to with the help of baseUrl when not explicitly set",
@@ -226,5 +203,16 @@ export const tests: ReadonlyArray<OneTest> = [
     requestedModule: "lib/mylib",
     expectedPath: undefined,
     extensions: defaultExtensionsWhenRunningInTsNode,
+  },
+  {
+    name: "should resolve main file with cjs file extension",
+    absoluteBaseUrl: "/root/",
+    paths: {},
+    existingFiles: [join("/root", "mylib", "index.cjs")],
+    packageJson: {
+      main: "./index.cjs",
+    },
+    requestedModule: "mylib",
+    expectedPath: join("/root", "mylib", "index.cjs"),
   },
 ];

--- a/src/match-path-async.ts
+++ b/src/match-path-async.ts
@@ -148,7 +148,6 @@ function findFirstExistingPath(
         return doneCallback(err);
       }
       if (exists) {
-        // Not sure why we don't just return the full path? Why strip it?
         return doneCallback(undefined, TryPath.getStrippedPath(tryPath));
       }
       if (index === tryPaths.length - 1) {
@@ -180,11 +179,7 @@ function findFirstExistingPath(
               return doneCallback(mainFieldErr);
             }
             if (mainFieldMappedFile) {
-              // Not sure why we don't just return the full path? Why strip it?
-              return doneCallback(
-                undefined,
-                Filesystem.removeExtension(mainFieldMappedFile)
-              );
+              return doneCallback(undefined, mainFieldMappedFile);
             }
 
             // No field in package json was a valid option. Continue with the next path.

--- a/src/match-path-sync.ts
+++ b/src/match-path-sync.ts
@@ -118,7 +118,6 @@ function findFirstExistingPath(
       tryPath.type === "index"
     ) {
       if (fileExists(tryPath.path)) {
-        // Not sure why we don't just return the full path? Why strip it?
         return TryPath.getStrippedPath(tryPath);
       }
     } else if (tryPath.type === "package") {
@@ -131,8 +130,7 @@ function findFirstExistingPath(
           fileExists
         );
         if (mainFieldMappedFile) {
-          // Not sure why we don't just return the full path? Why strip it?
-          return Filesystem.removeExtension(mainFieldMappedFile);
+          return mainFieldMappedFile;
         }
       }
     } else {


### PR DESCRIPTION
Originally during the file path resolution, file extensions were removed
without explicit reason. This commit changes the resolution logic to keep file
extensions, with the goal to add support for modern non-js extensions
like cjs. The change however keeps /xyz/index resolves as is as they
still should resolve to /xyz.

Refs 847d314