### PR TITLE
fix `yarn example:node` throw error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "start": "cd src && ts-node index.ts",
-    "example:node": "yarn build && cd ./example/node && ts-node -r ../register.js main.ts",
+    "example:node": "yarn build && cd ./example/node && ts-node -r ../../register.js main.ts",
     "example:project": "yarn build && ts-node -r ./register.js -P ./example/project/tsconfig.json ./example/project/main.ts",
     "example:api": "cd example/api && ts-node main.ts",
     "example:perf": "cd example/perf && ts-node main.ts",


### PR DESCRIPTION
when running `yarn example:node`, the below error happened because of the wrong path: `../register.js`

```
yarn example:node        
yarn run v1.22.10
$ yarn build && cd ./example/node && ts-node -r ../register.js main.ts
$ rimraf lib && tsc -p .
Error: Cannot find module '../register.js'
Require stack:
- internal/preload
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/Users/xxx/Lab/tsconfig-paths/node_modules/@cspotcode/source-map-support/source-map-support.js:679:30)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at Function.Module._preloadModules (internal/modules/cjs/loader.js:1244:12)
    at register (/Users/xxx/Lab/tsconfig-paths/node_modules/ts-node/src/index.ts:585:46)
    at phase4 (/Users/xxx/Lab/tsconfig-paths/node_modules/ts-node/src/bin.ts:480:11)
    at bootstrap (/Users/xxx/Lab/tsconfig-paths/node_modules/ts-node/src/bin.ts:85:10)
    at main (/Users/xxx/Lab/tsconfig-paths/node_modules/ts-node/src/bin.ts:54:10)
    at Object.<anonymous> (/Users/xxx/Lab/tsconfig-paths/node_modules/ts-node/src/bin.ts:717:3) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ 'internal/preload' ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```