### PR TITLE
feat(register): add `cwd` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `cwd` option to `register` function that overrides where the `tsconfig.json` search begins. See PR [#205](https://github.com/dividab/tsconfig-paths/pull/205).
+
 ## [3.14.1] - 2022-03-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ export interface ExplicitParams {
   paths: { [key: string]: Array<string> };
   mainFields?: Array<string>;
   addMatchAll?: boolean;
+  cwd?: string;
 }
 
 /**

--- a/src/register.ts
+++ b/src/register.ts
@@ -45,14 +45,22 @@ function getCoreModules(
   return coreModules;
 }
 
+export interface RegisterParams extends ExplicitParams {
+  /**
+   * Defaults to `--project` CLI flag or `process.cwd()`
+   */
+  cwd?: string;
+}
+
 /**
  * Installs a custom module load function that can adhere to paths in tsconfig.
  * Returns a function to undo paths registration.
  */
-export function register(explicitParams: ExplicitParams): () => void {
+export function register(params?: RegisterParams): () => void {
   const configLoaderResult = configLoader({
-    cwd: options.cwd,
-    explicitParams,
+    cwd: params?.cwd ?? options.cwd,
+    explicitParams:
+      params && (params.baseUrl || params.paths) ? params : undefined,
   });
 
   if (configLoaderResult.resultType === "failed") {


### PR DESCRIPTION
I'm hitting an edge case where my `process.cwd()` is not the value I want `register` to use.

This PR will let me circumvent that programatically.

```ts
require('tsconfig-paths').register({
  cwd: 'path/to/cwd',
})
```