### PR TITLE
Fix tests and lint

### DIFF
--- a/src/__tests__/config-loader.test.ts
+++ b/src/__tests__/config-loader.test.ts
@@ -19,9 +19,6 @@ describe("config-loader", (): void => {
     });
 
     const successResult = result as ConfigLoaderSuccessResult;
-    // assert.equal(successResult.resultType, "success");
-    // assert.equal(successResult.absoluteBaseUrl, "/foo/bar");
-    // assert.equal(successResult.paths["asd"][0], "asd");
     expect(successResult.resultType).toBe("success");
     expect(successResult.absoluteBaseUrl).toBe("/foo/bar");
     expect(successResult.paths["asd"][0]).toBe("asd");
@@ -39,8 +36,6 @@ describe("config-loader", (): void => {
     });
 
     const successResult = result as ConfigLoaderSuccessResult;
-    // assert.equal(successResult.resultType, "success");
-    // assert.equal(successResult.absoluteBaseUrl, join("/baz", "bar/"));
     expect(successResult.resultType).toBe("success");
     expect(successResult.absoluteBaseUrl).toBe(join("/baz", "bar/"));
   });
@@ -58,8 +53,6 @@ describe("config-loader", (): void => {
     });
 
     const successResult = result as ConfigLoaderSuccessResult;
-    // assert.equal(successResult.resultType, "success");
-    // assert.equal(successResult.absoluteBaseUrl, join("/baz", "src"));
     expect(successResult.resultType).toBe("success");
     expect(successResult.absoluteBaseUrl).toBe(join("/baz", "src"));
   });
@@ -89,8 +82,6 @@ describe("config-loader", (): void => {
     const result = loadConfig(configFile);
 
     const successResult = result as ConfigLoaderSuccessResult;
-    // assert.equal(successResult.resultType, "success");
-    // assert.equal(successResult.configFileAbsolutePath, configFile);
     expect(successResult.resultType).toBe("success");
     expect(successResult.configFileAbsolutePath).toBe(configFile);
   });

--- a/src/__tests__/config-loader.test.ts
+++ b/src/__tests__/config-loader.test.ts
@@ -102,7 +102,7 @@ describe("config-loader", (): void => {
     const result = configLoader({
       explicitParams: undefined,
       cwd: "/baz",
-      // tslint:disable-next-line:no-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       tsConfigLoader: (_: any) => ({
         tsConfigPath: "/baz/tsconfig.json",
         baseUrl: "/baz",
@@ -111,6 +111,6 @@ describe("config-loader", (): void => {
     });
 
     const successResult = result as ConfigLoaderSuccessResult;
-    assert.equal(successResult.absoluteBaseUrl, "/baz");
+    expect(successResult.absoluteBaseUrl).toEqual("/baz");
   });
 });

--- a/src/__tests__/config-loader.test.ts
+++ b/src/__tests__/config-loader.test.ts
@@ -44,8 +44,7 @@ describe("config-loader", (): void => {
     const result = configLoader({
       explicitParams: undefined,
       cwd: "/baz",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tsConfigLoader: (_: any) => ({
+      tsConfigLoader: () => ({
         tsConfigPath: "/baz/tsconfig.json",
         baseUrl: "./src",
         paths: {},
@@ -61,8 +60,7 @@ describe("config-loader", (): void => {
     const result = configLoader({
       explicitParams: undefined,
       cwd: "/baz",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tsConfigLoader: (_: any) => ({
+      tsConfigLoader: () => ({
         tsConfigPath: "/baz/tsconfig.json",
         baseUrl: undefined,
         paths: {},
@@ -90,8 +88,7 @@ describe("config-loader", (): void => {
     const result = configLoader({
       explicitParams: undefined,
       cwd: "/baz",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tsConfigLoader: (_: any) => ({
+      tsConfigLoader: () => ({
         tsConfigPath: "/baz/tsconfig.json",
         baseUrl: "/baz",
         paths: {},

--- a/src/__tests__/config-loader.test.ts
+++ b/src/__tests__/config-loader.test.ts
@@ -64,7 +64,7 @@ describe("config-loader", (): void => {
     expect(successResult.absoluteBaseUrl).toBe(join("/baz", "src"));
   });
 
-  it("should show an error message when baseUrl is missing", () => {
+  it("should tolerate a missing baseUrl", () => {
     const result = configLoader({
       explicitParams: undefined,
       cwd: "/baz",
@@ -77,10 +77,7 @@ describe("config-loader", (): void => {
     });
 
     const failResult = result as ConfigLoaderFailResult;
-    // assert.equal(failResult.resultType, "failed");
-    // assert.isTrue(failResult.message.indexOf("baseUrl") > -1);
-    expect(failResult.resultType).toBe("failed");
-    expect(failResult.message.indexOf("baseUrl") > -1).toBeTruthy();
+    expect(failResult.resultType).toBe("success");
   });
 
   it("should presume cwd to be a tsconfig file when loadConfig is called with absolute path to tsconfig.json", () => {

--- a/src/__tests__/filesystem.test.ts
+++ b/src/__tests__/filesystem.test.ts
@@ -7,20 +7,17 @@ describe("filesystem", () => {
 
   it("should find file that exists, sync", () => {
     const result = Filesystem.fileExistsSync(fileThatExists);
-    // assert.equal(result, true);
     expect(result).toBe(true);
   });
 
   it("should not find file that not exists, sync", () => {
     const result = Filesystem.fileExistsSync(fileThatNotExists);
-    // assert.equal(result, false);
     expect(result).toBe(false);
   });
 
   it("should find file that exists, async", (done) => {
     Filesystem.fileExistsAsync(fileThatExists, (_err, result) => {
       try {
-        // assert.equal(result, true);
         expect(result).toBe(true);
         done();
       } catch (error) {
@@ -32,7 +29,6 @@ describe("filesystem", () => {
   it("should not find file that not exists, async", (done) => {
     Filesystem.fileExistsAsync(fileThatNotExists, (_err, result) => {
       try {
-        // assert.equal(result, false);
         expect(result).toBe(false);
         done();
       } catch (error) {
@@ -43,18 +39,14 @@ describe("filesystem", () => {
 
   it("should load json, sync", () => {
     const result = Filesystem.readJsonFromDiskSync(fileThatExists);
-    // assert.isOk(result);
     expect(result);
-    // assert.equal(result.main, "lib/index.js");
     expect(result.main).toBe("lib/index.js");
   });
 
   it("should load json, async", (done) => {
     Filesystem.readJsonFromDiskAsync(fileThatExists, (_err, result) => {
       try {
-        // assert.isOk(result); // Asserts that object is truthy.
         expect(result).toBeTruthy();
-        // assert.equal(result.main, "lib/index.js");
         expect(result.main).toBe("lib/index.js");
         done();
       } catch (error) {

--- a/src/__tests__/mapping-entry.test.ts
+++ b/src/__tests__/mapping-entry.test.ts
@@ -6,29 +6,12 @@ describe("mapping-entry", () => {
     const result = getAbsoluteMappingEntries(
       "/absolute/base/url",
       {
-        "*": ["/foo1", "/foo2"],
-        "longest/pre/fix/*": ["/foo2/bar"],
+        "*": ["/foo1", "./foo2"],
+        "longest/pre/fix/*": ["./foo2/bar"],
         "pre/fix/*": ["/foo3"],
       },
       true
     );
-    // assert.deepEqual(result, [
-    //   {
-    //     pattern: "longest/pre/fix/*",
-    //     paths: [join("/absolute", "base", "url", "foo2", "bar")],
-    //   },
-    //   {
-    //     pattern: "pre/fix/*",
-    //     paths: [join("/absolute", "base", "url", "foo3")],
-    //   },
-    //   {
-    //     pattern: "*",
-    //     paths: [
-    //       join("/absolute", "base", "url", "foo1"),
-    //       join("/absolute", "base", "url", "foo2"),
-    //     ],
-    //   },
-    // ]);
     expect(result).toEqual([
       {
         pattern: "longest/pre/fix/*",
@@ -36,26 +19,17 @@ describe("mapping-entry", () => {
       },
       {
         pattern: "pre/fix/*",
-        paths: [join("/absolute", "base", "url", "foo3")],
+        paths: [join("/foo3")],
       },
       {
         pattern: "*",
-        paths: [
-          join("/absolute", "base", "url", "foo1"),
-          join("/absolute", "base", "url", "foo2"),
-        ],
+        paths: [join("/foo1"), join("/absolute", "base", "url", "foo2")],
       },
     ]);
   });
 
   it("should should add a match-all pattern when requested", () => {
     let result = getAbsoluteMappingEntries("/absolute/base/url", {}, true);
-    // assert.deepEqual(result, [
-    //   {
-    //     pattern: "*",
-    //     paths: [join("/absolute", "base", "url", "*")],
-    //   },
-    // ]);
     expect(result).toEqual([
       {
         pattern: "*",
@@ -64,7 +38,6 @@ describe("mapping-entry", () => {
     ]);
 
     result = getAbsoluteMappingEntries("/absolute/base/url", {}, false);
-    // assert.deepEqual(result, []);
     expect(result).toEqual([]);
   });
 });

--- a/src/__tests__/match-path-async.test.ts
+++ b/src/__tests__/match-path-async.test.ts
@@ -17,7 +17,6 @@ describe("match-path-async", () => {
           callback(undefined, t.existingFiles.indexOf(path) !== -1),
         t.extensions,
         (_err, result) => {
-          // assert.equal(result, t.expectedPath);
           expect(result).toBe(t.expectedPath);
           done();
         }

--- a/src/__tests__/match-path-sync.test.ts
+++ b/src/__tests__/match-path-sync.test.ts
@@ -16,7 +16,6 @@ describe("match-path-sync", () => {
         (name: string) => t.existingFiles.indexOf(name) !== -1,
         t.extensions
       );
-      // assert.equal(result, t.expectedPath);
       expect(result).toBe(t.expectedPath);
     })
   );

--- a/src/__tests__/try-path.test.ts
+++ b/src/__tests__/try-path.test.ts
@@ -26,7 +26,6 @@ describe("mapping-entry", () => {
       abosolutePathMappings,
       "./requested-module"
     );
-    // assert.deepEqual(result, undefined);
     expect(result).toBeUndefined();
   });
 
@@ -54,46 +53,6 @@ describe("mapping-entry", () => {
       abosolutePathMappings,
       "longest/pre/fix/requested-module"
     );
-    // assert.deepEqual(result, [
-    //   // "longest/pre/fix/*"
-    //   { type: "file", path: join("/absolute", "base", "url", "foo2", "bar") },
-    //   {
-    //     type: "extension",
-    //     path: join("/absolute", "base", "url", "foo2", "bar.ts"),
-    //   },
-    //   {
-    //     type: "extension",
-    //     path: join("/absolute", "base", "url", "foo2", "bar.tsx"),
-    //   },
-    //   {
-    //     type: "package",
-    //     path: join("/absolute", "base", "url", "foo2", "bar", "package.json"),
-    //   },
-    //   {
-    //     type: "index",
-    //     path: join("/absolute", "base", "url", "foo2", "bar", "index.ts"),
-    //   },
-    //   {
-    //     type: "index",
-    //     path: join("/absolute", "base", "url", "foo2", "bar", "index.tsx"),
-    //   },
-    //   // "*"
-    //   { type: "file", path: join("/absolute", "base", "url", "foo1") },
-    //   { type: "extension", path: join("/absolute", "base", "url", "foo1.ts") },
-    //   { type: "extension", path: join("/absolute", "base", "url", "foo1.tsx") },
-    //   {
-    //     type: "package",
-    //     path: join("/absolute", "base", "url", "foo1", "package.json"),
-    //   },
-    //   {
-    //     type: "index",
-    //     path: join("/absolute", "base", "url", "foo1", "index.ts"),
-    //   },
-    //   {
-    //     type: "index",
-    //     path: join("/absolute", "base", "url", "foo1", "index.tsx"),
-    //   },
-    // ]);
     expect(result).toEqual([
       // "longest/pre/fix/*"
       { type: "file", path: join("/absolute", "base", "url", "foo2", "bar") },
@@ -180,14 +139,3 @@ describe("mapping-entry", () => {
     ]);
   });
 });
-
-// describe("match-star", () => {
-//   it("should match star in last position", () => {
-//     const result = matchStar("lib/*", "lib/mylib");
-//     assert.equal(result, "mylib");
-//   });
-//   it("should match star in first position", () => {
-//     const result = matchStar("*/lib", "mylib/lib");
-//     assert.equal(result, "mylib");
-//   });
-// });

--- a/src/__tests__/tsconfig-loader.test.ts
+++ b/src/__tests__/tsconfig-loader.test.ts
@@ -19,7 +19,6 @@ describe("tsconfig-loader", () => {
       },
     });
 
-    // assert.equal(result.tsConfigPath, "/foo/bar/tsconfig.json");
     expect(result.tsConfigPath).toBe("/foo/bar/tsconfig.json");
   });
 
@@ -36,7 +35,6 @@ describe("tsconfig-loader", () => {
       },
     });
 
-    // assert.isUndefined(result.tsConfigPath);
     expect(result.tsConfigPath).toBeUndefined();
   });
 
@@ -62,7 +60,6 @@ describe("tsconfig-loader", () => {
       },
     });
 
-    // assert.equal(result.tsConfigPath, "/foo/baz/tsconfig.json");
     expect(result.tsConfigPath).toBe("/foo/baz/tsconfig.json");
   });
 
@@ -80,7 +77,6 @@ describe("tsconfig-loader", () => {
       },
     });
 
-    // assert.equal(result.baseUrl, "SOME_BASEURL");
     expect(result.baseUrl).toBe("SOME_BASEURL");
   });
 
@@ -99,7 +95,6 @@ describe("tsconfig-loader", () => {
       },
     });
 
-    // assert.equal(result.baseUrl, undefined);
     expect(result.baseUrl).toBeUndefined();
   });
 });
@@ -180,7 +175,6 @@ describe("loadConfig", () => {
       (path) => path === "/root/dir1/tsconfig.json",
       (_) => JSON.stringify(config)
     );
-    // assert.deepEqual(res, config);
     expect(res).toStrictEqual(config);
   });
 
@@ -196,7 +190,6 @@ describe("loadConfig", () => {
           }
         }`
     );
-    // assert.deepEqual(res, config);
     expect(res).toStrictEqual(config);
   });
 
@@ -211,7 +204,6 @@ describe("loadConfig", () => {
           },
         }`
     );
-    // assert.deepEqual(res, config);
     expect(res).toStrictEqual(config);
   });
 
@@ -243,14 +235,6 @@ describe("loadConfig", () => {
       }
     );
 
-    // assert.deepEqual(res, {
-    //   extends: "../base-config.json",
-    //   compilerOptions: {
-    //     baseUrl: "kalle",
-    //     paths: { foo: ["bar2"] },
-    //     strict: true,
-    //   },
-    // });
     expect(res).toEqual({
       extends: "../base-config.json",
       compilerOptions: {
@@ -295,14 +279,6 @@ describe("loadConfig", () => {
       }
     );
 
-    // assert.deepEqual(res, {
-    //   extends: "my-package/base-config.json",
-    //   compilerOptions: {
-    //     baseUrl: "kalle",
-    //     paths: { foo: ["bar2"] },
-    //     strict: true,
-    //   },
-    // });
     expect(res).toEqual({
       extends: "my-package/base-config.json",
       compilerOptions: {
@@ -340,10 +316,6 @@ describe("loadConfig", () => {
       }
     );
 
-    // assert.deepEqual(res, {
-    //   extends: "../second-config.json",
-    //   compilerOptions: { baseUrl: join("..", "..") },
-    // });
     expect(res).toEqual({
       extends: "../second-config.json",
       compilerOptions: { baseUrl: join("..", "..") },


### PR DESCRIPTION
This fixes the failing test called out in https://github.com/dividab/tsconfig-paths/pull/174#discussion_r863079371. It also fixes a few more failing tests. The entire test suite now passes!

I also took the opportunity to remove some commented-out assertions and remove a few unnecessary bits that had `// eslint-disable...` comments.

I would strongly encourage the maintainers to set up CI to run on pull requests, not just on master, so that errors can be caught quickly and resolved before changes are merged!