### PR TITLE
Explicitly specify minimum Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "LICENSE",
     "README.md"
   ],
+  "engines": {
+    "node": ">=6"
+  },
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "@types/minimist": "^1.2.2",


### PR DESCRIPTION
After https://github.com/dividab/tsconfig-paths/pull/198, `tsconfig-paths`'s minimum Node.js version is v6. I thinks we would better specify minimum Node.js version explicitly