### PR TITLE
test: should resolve .ts from .js alias

### DIFF
--- a/src/__tests__/data/match-path-data.ts
+++ b/src/__tests__/data/match-path-data.ts
@@ -216,4 +216,15 @@ export const tests: ReadonlyArray<OneTest> = [
     expectedPath: join("/root", "mylib", "index.cjs"),
     extensions: defaultExtensionsWhenRunningInTsNode,
   },
+  {
+    name: "should resolve .ts from .js alias",
+    absoluteBaseUrl: "/root/",
+    paths: {
+      "@/*": ["src/*"],
+    },
+    existingFiles: [join("/root", "src", "foo.ts")],
+    requestedModule: "@/foo.js",
+    expectedPath: join("/root", "src", "foo.ts"),
+    extensions: defaultExtensionsWhenRunningInTsNode,
+  },
 ];


### PR DESCRIPTION
This test confirms a bug reported in https://github.com/aleclarson/vite-tsconfig-paths/issues/54

TypeScript allows importing a TypeScript module using a `.js` extension, and a `.jsx` extension for TSX modules.