### PR TITLE
fixed resolve root directory

### DIFF
--- a/src/mapping-entry.ts
+++ b/src/mapping-entry.ts
@@ -39,7 +39,7 @@ export function getAbsoluteMappingEntries(
   }
   // If there is no match-all path specified in the paths section of tsconfig, then try to match
   // all paths relative to baseUrl, this is how typescript works.
-  if (!paths["*"] && addMatchAll) {
+  if (!paths["*"] && addMatchAll && absoluteBaseUrl !== "/") {
     absolutePaths.push({
       pattern: "*",
       paths: [`${absoluteBaseUrl.replace(/\/$/, "")}/*`],


### PR DESCRIPTION
The bug was found in https://github.com/nestjs/nest/issues/9504.
When using the Dockerfile and the root directory in it, the script crashed into an infinite loop
