### PR TITLE
Fix missing paths when using typescript's module nodenext feature

### DIFF
--- a/src/__tests__/data/match-path-data.ts
+++ b/src/__tests__/data/match-path-data.ts
@@ -216,4 +216,15 @@ export const tests: ReadonlyArray<OneTest> = [
     expectedPath: join("/root", "mylib", "index.cjs"),
     extensions: defaultExtensionsWhenRunningInTsNode,
   },
+  {
+    name: "should resolve .ts from .js alias",
+    absoluteBaseUrl: "/root/",
+    paths: {
+      "@/*": ["src/*"],
+    },
+    existingFiles: [join("/root", "src", "foo.ts")],
+    requestedModule: "@/foo.js",
+    expectedPath: join("/root", "src", "foo"),
+    extensions: defaultExtensionsWhenRunningInTsNode,
+  },
 ];

--- a/src/__tests__/try-path.test.ts
+++ b/src/__tests__/try-path.test.ts
@@ -95,6 +95,32 @@ describe("mapping-entry", () => {
     ]);
   });
 
+  it("should include paths with ending .js removed that matches requested module", () => {
+    const result = getPathsToTry(
+      [".ts", ".tsx"],
+      [
+        {
+          pattern: "longest/pre/fix/*",
+          paths: [join("/absolute", "base", "url", "foo2", "*")],
+        },
+      ],
+      "longest/pre/fix/bar.js"
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          type: "extension",
+          path: join("/absolute", "base", "url", "foo2", "bar.ts"),
+        },
+        {
+          type: "extension",
+          path: join("/absolute", "base", "url", "foo2", "bar.tsx"),
+        },
+      ])
+    );
+  });
+
   it("should resolve paths starting with a slash", () => {
     const result = getPathsToTry(
       [".ts"],

--- a/src/__tests__/try-path.test.ts
+++ b/src/__tests__/try-path.test.ts
@@ -95,31 +95,78 @@ describe("mapping-entry", () => {
     ]);
   });
 
-  it("should include paths with ending .js removed that matches requested module", () => {
-    const result = getPathsToTry(
-      [".ts", ".tsx"],
-      [
-        {
-          pattern: "longest/pre/fix/*",
-          paths: [join("/absolute", "base", "url", "foo2", "*")],
-        },
-      ],
-      "longest/pre/fix/bar.js"
-    );
+  it.each(["js", "jsx", "mjs", "cjs"])(
+    "should include paths with ending .%s removed that matches requested module",
+    (extension) => {
+      const result = getPathsToTry(
+        [".ts", ".tsx"],
+        [
+          {
+            pattern: "longest/pre/fix/*",
+            paths: [join("/absolute", "base", "url", "foo2", "*")],
+          },
+        ],
+        `longest/pre/fix/bar.${extension}`
+      );
 
-    expect(result).toEqual(
-      expect.arrayContaining([
-        {
-          type: "extension",
-          path: join("/absolute", "base", "url", "foo2", "bar.ts"),
-        },
-        {
-          type: "extension",
-          path: join("/absolute", "base", "url", "foo2", "bar.tsx"),
-        },
-      ])
-    );
-  });
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            type: "extension",
+            path: join("/absolute", "base", "url", "foo2", "bar.ts"),
+          },
+          {
+            type: "extension",
+            path: join("/absolute", "base", "url", "foo2", "bar.tsx"),
+          },
+        ])
+      );
+    }
+  );
+
+  it.each([
+    ["mjs", "mts"],
+    ["cjs", "cts"],
+  ])(
+    "should include paths with ending .%s removed that matches requested module with extension .%s",
+    (requestedModuleExtension, expectedExtension) => {
+      const result = getPathsToTry(
+        [".ts", ".tsx", `.${expectedExtension}`, `.${expectedExtension}x`],
+        [
+          {
+            pattern: "longest/pre/fix/*",
+            paths: [join("/absolute", "base", "url", "foo2", "*")],
+          },
+        ],
+        `longest/pre/fix/bar.${requestedModuleExtension}`
+      );
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            type: "extension",
+            path: join(
+              "/absolute",
+              "base",
+              "url",
+              "foo2",
+              `bar.${expectedExtension}`
+            ),
+          },
+          {
+            type: "extension",
+            path: join(
+              "/absolute",
+              "base",
+              "url",
+              "foo2",
+              `bar.${expectedExtension}x`
+            ),
+          },
+        ])
+      );
+    }
+  );
 
   it("should resolve paths starting with a slash", () => {
     const result = getPathsToTry(

--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -24,6 +24,7 @@ export function getPathsToTry(
     return undefined;
   }
 
+  const suffixRegex = /\.(c|m)?jsx?$/;
   const pathsToTry: Array<TryPath> = [];
   for (const entry of absolutePathMappings) {
     const starMatch =
@@ -39,13 +40,13 @@ export function getPathsToTry(
             (e) => ({ type: "extension", path: physicalPath + e } as TryPath)
           )
         );
-        if (physicalPath.endsWith(".js")) {
+        if (physicalPath.match(suffixRegex)) {
           pathsToTry.push(
             ...extensions.map(
               (e) =>
                 ({
                   type: "extension",
-                  path: physicalPath.replace(/\.js$/, "") + e,
+                  path: physicalPath.replace(suffixRegex, "") + e,
                 } as TryPath)
             )
           );

--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -39,6 +39,17 @@ export function getPathsToTry(
             (e) => ({ type: "extension", path: physicalPath + e } as TryPath)
           )
         );
+        if (physicalPath.endsWith(".js")) {
+          pathsToTry.push(
+            ...extensions.map(
+              (e) =>
+                ({
+                  type: "extension",
+                  path: physicalPath.replace(/\.js$/, "") + e,
+                } as TryPath)
+            )
+          );
+        }
         pathsToTry.push({
           type: "package",
           path: path.join(physicalPath, "/package.json"),


### PR DESCRIPTION
This resolution requires relative/mapped import paths to end with .js
This PR detects if a path ends with `.js` and if so adds more extension type paths to try, that omit this extension when attaching additional extensions to match the actual existing files.

Reference https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#esm-nodejs

Should resolve https://github.com/dividab/tsconfig-paths/pull/213 (edit 1: wrong issue sorry, edit 2: actually I believe this **might** resolve that issue as well) & https://github.com/aleclarson/vite-tsconfig-paths/issues/59