### PR TITLE
Export ConfigLoaderParams in package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   ConfigLoaderResult,
   ConfigLoaderSuccessResult,
   ConfigLoaderFailResult,
+  ConfigLoaderParams,
 } from "./config-loader";
 export {
   ReadJsonSync,


### PR DESCRIPTION
This PR adds no new functionality, but exports the `ConfigLoaderParams` type, which can help with better typing in downstream packages.