### PR TITLE
Skip stat call / throwing an exception when source files don't exist

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -33,6 +33,10 @@ export interface ReadJsonAsync {
 }
 
 export function fileExistsSync(path: string): boolean {
+  // If the file doesn't exist, avoid throwing an exception over the native barrier for every miss
+  if (!fs.existsSync(path)) {
+    return false;
+  }
   try {
     const stats = fs.statSync(path);
     return stats.isFile();


### PR DESCRIPTION
I noticed that as the number of tried file paths goes up, Node.js spends a lot of time preparing a native exception to throw over the JS barrier. I narrowed this down to be a result of relying on the `fs.statSync` call in `fileExistsSync` to determine whether or not the file exists on top of whether or not it is actually a file. 

Prepending a call to `fs.existsSync` allows us to skip the preparation time of throwing an exception at the cost of causing another IO hit. There is ostensibly some sort of tradeoff but for the large monolithic app I work on, this shaves off the vast majority of the boot and hot reload time.[1]

Happy to discuss / prepare a more detailed breakdown if necessary.

1: 6x improvement in boot time on ~6k JS source files