### PR TITLE
Make extensions configurable

### DIFF
--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -6,6 +6,7 @@ export interface ExplicitParams {
   paths: { [key: string]: Array<string> };
   mainFields?: (string | string[])[];
   addMatchAll?: boolean;
+  extensions?: ReadonlyArray<string>
 }
 
 export type TsConfigLoader = (

--- a/src/match-path-sync.ts
+++ b/src/match-path-sync.ts
@@ -28,7 +28,8 @@ export function createMatchPath(
   absoluteBaseUrl: string,
   paths: { [key: string]: Array<string> },
   mainFields: (string | string[])[] = ["main"],
-  addMatchAll: boolean = true
+  addMatchAll: boolean = true,
+  extensions?: ReadonlyArray<string>
 ): MatchPath {
   const absolutePaths = MappingEntry.getAbsoluteMappingEntries(
     absoluteBaseUrl,
@@ -40,7 +41,6 @@ export function createMatchPath(
     requestedModule: string,
     readJson?: Filesystem.ReadJsonSync,
     fileExists?: Filesystem.FileExistsSync,
-    extensions?: Array<string>
   ) =>
     matchFromAbsolutePaths(
       absolutePaths,
@@ -68,7 +68,7 @@ export function matchFromAbsolutePaths(
   requestedModule: string,
   readJson: Filesystem.ReadJsonSync = Filesystem.readJsonFromDiskSync,
   fileExists: Filesystem.FileExistsSync = Filesystem.fileExistsSync,
-  extensions: Array<string> = Object.keys(require.extensions),
+  extensions: ReadonlyArray<string> = Object.keys(require.extensions),
   mainFields: (string | string[])[] = ["main"]
 ): string | undefined {
   const tryPaths = TryPath.getPathsToTry(

--- a/src/register.ts
+++ b/src/register.ts
@@ -93,7 +93,8 @@ export function register(params?: RegisterParams): () => void {
     configLoaderResult.absoluteBaseUrl,
     configLoaderResult.paths,
     configLoaderResult.mainFields,
-    configLoaderResult.addMatchAll
+    configLoaderResult.addMatchAll,
+    explicitParams?.extensions,
   );
 
   // Patch node's module loading


### PR DESCRIPTION
The number of entries in `require.extensions` can make lookups needlessly slow. Most apps will probably only use the `tsx`/`ts`/`js` extensions, so it doesn't make sense to iterate through a bunch of paths that we _know_ are extremely unlikely to hit.