### PR TITLE
Bump JSON5 dependency to 2.2.2 to fix CVE-2022-46175

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsconfig-paths",
-  "version": "4.1.2",
+  "version": "4.1.1",
   "description": "Load node modules according to tsconfig paths, in run-time or via API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsconfig-paths",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Load node modules according to tsconfig paths, in run-time or via API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "json5": "^2.2.1",
+    "json5": "^2.2.2",
     "minimist": "^1.2.6",
     "strip-bom": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,10 +2848,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
+  integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
 kleur@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Versions of JSON5 < 2.2.2 are susceptible to CVE-2022-46175.

This PR bumps this project's dependency to 2.2.2, which resolves this vulnerability. There are no other changes / no breaking changes in the version bump ([changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md#v222-code-diff))