### PR TITLE
Skip stat call / throwing an exception when source files don't exist in v3 (Backport of #225)

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -33,6 +33,10 @@ export interface ReadJsonAsync {
 }
 
 export function fileExistsSync(path: string): boolean {
+  // If the file doesn't exist, avoid throwing an exception over the native barrier for every miss
+  if (!fs.existsSync(path)) {
+    return false;
+  }
   try {
     const stats = fs.statSync(path);
     return stats.isFile();


### PR DESCRIPTION
I saw that in #260 @jonaskello is amenable to backporting features to the v3 branch, as the majority of users are still on v3, (mostly thanks to the strong backwards compatability promises made by `eslint-plugin-import`).

This PR backports #225 to v3.15 - no editing needed, it's just a cherry-pick. 

Details in #225 suggests that this offers a solid speed improvement. https://github.com/import-js/eslint-plugin-import/pull/2654 proposed updating `tsconfig-paths` from v3 to v4 in eslint-plugin-import as this change resulted in a 10-20% speed improvement in large repositories - I suspect in large part due to this one performance change. That PR was ultimately rejected due to `eslint-plugin-import` supporting a long tail of node versions, and thus wanting to stay on tsconfig-paths v3. `eslint-plugin-import`'s author suggested backporting the performance fix to v3 so they could take advantage of it.

#225 was released as a patch version, so I assume this would be too.