### PR TITLE
fix: extensions

### DIFF
--- a/src/match-path-async.ts
+++ b/src/match-path-async.ts
@@ -62,7 +62,7 @@ export function matchFromAbsolutePathsAsync(
   requestedModule: string,
   readJson: Filesystem.ReadJsonAsync = Filesystem.readJsonFromDiskAsync,
   fileExists: Filesystem.FileExistsAsync = Filesystem.fileExistsAsync,
-  extensions: ReadonlyArray<string> = Object.keys(require.extensions),
+  extensions: ReadonlyArray<string> = ['.ts','.tsx','.js','.jsx','.mjs','.cjs','.json','.node'],
   callback: MatchPathAsyncCallback,
   mainFields: (string | string[])[] = ["main"]
 ): void {

--- a/src/match-path-sync.ts
+++ b/src/match-path-sync.ts
@@ -68,7 +68,7 @@ export function matchFromAbsolutePaths(
   requestedModule: string,
   readJson: Filesystem.ReadJsonSync = Filesystem.readJsonFromDiskSync,
   fileExists: Filesystem.FileExistsSync = Filesystem.fileExistsSync,
-  extensions: Array<string> = Object.keys(require.extensions),
+  extensions: Array<string> = ['.ts','.tsx','.js','.jsx','.mjs','.cjs','.json','.node'],
   mainFields: (string | string[])[] = ["main"]
 ): string | undefined {
   const tryPaths = TryPath.getPathsToTry(


### PR DESCRIPTION
- require.extensions is deprecated and doesn't include all JS extensions such as .ts, .mjs, ...

fixes: https://github.com/dividab/tsconfig-paths/issues/248