### PR TITLE
Change config context when referencing outside the main project

### DIFF
--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -1,4 +1,5 @@
 import * as TsConfigLoader2 from "./tsconfig-loader";
+import { MatchPath, createMatchPath } from "./match-path-sync";
 import * as path from "path";
 
 export interface ExplicitParams {
@@ -85,5 +86,34 @@ export function configLoader({
     ),
     paths: loadResult.paths || {},
     addMatchAll: loadResult.baseUrl !== undefined,
+  };
+}
+
+export function findConfigMatcher({
+  cwd,
+  explicitParams,
+}: ConfigLoaderParams): { config: ConfigLoaderResult; matchPath: MatchPath } {
+  const configLoaderResult = configLoader({
+    cwd,
+    explicitParams,
+  });
+
+  if (configLoaderResult.resultType === "failed") {
+    console.warn(
+      "".concat(configLoaderResult.message, ". tsconfig-paths will be skipped")
+    );
+    return noOp;
+  }
+
+  const matchPath = createMatchPath(
+    configLoaderResult.absoluteBaseUrl,
+    configLoaderResult.paths,
+    configLoaderResult.mainFields,
+    configLoaderResult.addMatchAll
+  );
+
+  return {
+    config: configLoaderResult,
+    matchPath,
   };
 }


### PR DESCRIPTION
This PR intends to tackle the issue reported in https://github.com/dividab/tsconfig-paths/issues/153

When referencing files from other modules with their own configs, the primary config will no longer be used, but rather then initiate a new search for a configuration in the destination project which will then be cached for successive requests.